### PR TITLE
Changed specify path from pathces to resources about ingress.yaml

### DIFF
--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ingress.yaml
 patches:
   - path: deployment.yaml
   - path: service.yaml
-  - path: ingress.yaml


### PR DESCRIPTION
Kustomize側でingress.yamlが認知できなかったため、resourcesに指定して改善されるかを確認する

以下、ChatGPTによる解凍
```
このエラーメッセージは、以下のように解釈できます：

kustomize build コマンドが失敗した。
指定されたingress.yamlのパッチを適用しようとしたが、ターゲットのリソースが見つからなかった。
Ingress.v1.networking.k8s.io/shanari-shanari-ingress.[noNs]に一致するリソースが存在しない。
修正方法
この問題を修正するためには、ingress.yamlをパッチではなくリソースとして追加する必要があります。patchesStrategicMergeの代わりに、resourcesフィールドに追加することで解決できます。
```