### PR TITLE
Update name of defaultBackend

### DIFF
--- a/kustomize/overlays/prod/ingress.yaml
+++ b/kustomize/overlays/prod/ingress.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   defaultBackend:
     service:
-      name: shanari-backend
+      name: shanari-shanari-service
       port:
         number: 80


### PR DESCRIPTION
```
Translation failed: invalid ingress spec: could not find service "shanari-shanari/shanari-backend"
```
のため、defaultBackendの指定するservice名をserivceのmetadataに更新した